### PR TITLE
scrollTop wrong value fix

### DIFF
--- a/src/js/lib/Scrollspy.jsx
+++ b/src/js/lib/Scrollspy.jsx
@@ -63,7 +63,7 @@ Scrollspy = React.createClass({
 
   _isInView: function (el) {
     var winH = win.innerHeight,
-      scrollTop = doc.body.scrollTop,
+      scrollTop = doc.documentElement.scrollTop || doc.body.scrollTop,
       scrollBottom = scrollTop + winH,
       elTop = el.offsetTop,
       elBottom = elTop + el.offsetHeight;


### PR DESCRIPTION
document.body.scrollTop was always returning 0, hence the plugin was not working properly. It wasn't setting the active class on clicking or on scroll to the appropriate list element. document.documentElement.scrollTop seems to work