### PR TITLE
Correctly unbind scroll event to avoid memory leak

### DIFF
--- a/src/js/lib/Scrollspy.jsx
+++ b/src/js/lib/Scrollspy.jsx
@@ -23,6 +23,9 @@ export class Scrollspy extends React.Component {
       targetItems: [],
       inViewState: [],
     }
+    // manually bind as ES6 does not apply this
+    // auto binding as React.createClass does
+    this._handleSpy = this._handleSpy.bind(this)
   }
 
   _initSpyTarget (items) {
@@ -103,11 +106,11 @@ export class Scrollspy extends React.Component {
 
   componentDidMount () {
     this._initFromProps()
-    window.addEventListener('scroll', this._handleSpy.bind(this))
+    window.addEventListener('scroll', this._handleSpy)
   }
 
   componentWillUnmount () {
-    window.removeEventListener('scroll', this._handleSpy.bind(this))
+    window.removeEventListener('scroll', this._handleSpy)
   }
 
   componentWillReceiveProps () {


### PR DESCRIPTION
## The problem
I came across this error using your plugin in a multipage app where client side routing is used. When navigating to a new page the old scroll event continues to fire leading to the error "setState(…): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op"

## The reason
When using ES6 classes, functions do not get automatically bound to `this` like when using `React.createClass()`

So removing the scroll event like this `window.removeEventListener('scroll', this._handleSpy.bind(this))` does not work because `.bind()` returns a new instance each time you call it.

Instead you can bind your function in the constructor of your class that way the same function instance is always being used when adding and removing the listeners.