### PR TITLE
Check if bottom of page was reached

### DIFF
--- a/src/js/lib/Scrollspy.jsx
+++ b/src/js/lib/Scrollspy.jsx
@@ -57,6 +57,18 @@ export class Scrollspy extends React.Component {
         elemsOutView.push(currentContent)
       }
 
+      if (this._isAtEnd() &&                // We have reached the end,
+          this._isInView(currentContent) && // and the last element is visible,
+          !isInView &&                      // but not triggered.          
+          i===max-1 &&                      
+          (document.documentElement.scrollTop || document.body.scrollTop)>0) { // Only if we have scrolled.
+        elemsOutView.pop()                 // Cancel adding this element to elemsOutView.
+        elemsOutView.push(...elemsInView)  // Transfer everything from elemsInView to elemsOutView,
+        elemsInView = [currentContent]     // and make current element the only elemsInView element.
+        viewStatusList.fill(false)         // Make other elements false,
+        isInView = true                    // and this element true.
+      }
+
       viewStatusList.push(isInView)
     }
 
@@ -77,6 +89,14 @@ export class Scrollspy extends React.Component {
     const elBottom = elTop + el.offsetHeight
 
     return (elTop < scrollBottom) && (elBottom > scrollTop)
+  }
+
+  _isAtEnd () {
+    const scrollTop = (document.documentElement && document.documentElement.scrollTop) || document.body.scrollTop
+    const scrollHeight = (document.documentElement && document.documentElement.scrollHeight) || document.body.scrollHeight
+    const scrolledToBottom = (scrollTop + window.innerHeight) >= scrollHeight
+    
+    return scrolledToBottom
   }
 
   _spy (targets) {


### PR DESCRIPTION
In some cases, the last element can be very short and will never be the only visible element. That causes some awkward situations when you click the last link on a navbar, it doesn't get activated.

So, I added a check that if we are at the bottom of the page, the last element in the items array will be the active one. We could put this check behind a prop trigger but I don't think it is necessary?