### PR TITLE
add check for bottom

### DIFF
--- a/src/js/lib/Scrollspy.jsx
+++ b/src/js/lib/Scrollspy.jsx
@@ -57,6 +57,18 @@ export class Scrollspy extends React.Component {
         elemsOutView.push(currentContent)
       }
 
+      if (this._isAtEnd() &&
+      this._isInView(currentContent) &&
+      !isInView &&
+      i === max - 1 &&
+      (document.documentElement.scrollTop || document.body.scrollTop) > 0) {
+        elemsOutView.pop()
+        elemsOutView.push(...elemsInView)
+        elemsInView = [currentContent]
+        viewStatusList.fill(false)
+        isInView = true
+      }
+
       viewStatusList.push(isInView)
     }
 
@@ -79,6 +91,13 @@ export class Scrollspy extends React.Component {
     return (elTop < scrollBottom) && (elBottom > scrollTop)
   }
 
+  _isAtEnd () {
+    const scrollTop = (document.documentElement && document.documentElement.scrollTop) || document.body.scrollTop
+    const scrollHeight = (document.documentElement && document.documentElement.scrollHeight) || document.body.scrollHeight
+    const scrolledToBottom = (scrollTop + window.innerHeight) >= scrollHeight
+
+    return scrolledToBottom
+  }
   _spy (targets) {
     this.setState({
       inViewState: this._getElemsViewState(targets).viewStatusList,


### PR DESCRIPTION
In some cases, the last element can be very short and will never be the only visible element. That causes some awkward situations when you click the last link on a navbar, it doesn't get activated.

So, I added a check that if we are at the bottom of the page, the last element in the items array will be the active one. We could put this check behind a prop trigger but I don't know if it is necessary?