### PR TITLE
Handling new props

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "gulp-ejs": "^1.2.2",
     "gulp-eslint": "^1.1.1",
     "gulp-sass": "^2.2.0",
+    "jsdom": "^9.4.2",
     "jsx-test-helpers": "^1.1.0",
     "react": "^15.3.0",
     "react-addons-test-utils": "^15.3.0",

--- a/src/js/lib/Scrollspy.jsx
+++ b/src/js/lib/Scrollspy.jsx
@@ -119,8 +119,8 @@ export class Scrollspy extends React.Component {
     timer = setTimeout(this._spy.bind(this), 100)
   }
 
-  _initFromProps () {
-    const targetItems = this._initSpyTarget(this.props.items)
+  _initFromProps (props = this.props) {
+    const targetItems = this._initSpyTarget(props.items)
 
     this.setState({
       targetItems,
@@ -138,8 +138,8 @@ export class Scrollspy extends React.Component {
     window.removeEventListener('scroll', this._handleSpy)
   }
 
-  componentWillReceiveProps () {
-    this._initFromProps()
+  componentWillReceiveProps (nextProps) {
+    this._initFromProps(nextProps)
   }
 
   render () {

--- a/test/document.js
+++ b/test/document.js
@@ -1,0 +1,17 @@
+// https://github.com/airbnb/enzyme/blob/master/docs/guides/jsdom.md
+
+var jsdom = require('jsdom').jsdom
+var exposedProperties = ['window', 'navigator', 'document']
+
+global.document = jsdom('')
+global.window = document.defaultView
+Object.keys(document.defaultView).forEach((property) => {
+  if (typeof global[property] === 'undefined') {
+    exposedProperties.push(property)
+    global[property] = document.defaultView[property]
+  }
+})
+
+global.navigator = {
+  userAgent: 'node.js'
+}

--- a/test/test.js
+++ b/test/test.js
@@ -32,3 +32,14 @@ test('render correct children length', (t) => {
   )
   t.is(wrapper.find('li').length, 3)
 })
+test('should update targetItems after receiving new props', (t) => {
+  const wrapper = mount(
+    <Scrollspy items={ [] } />
+  )
+
+  t.is(wrapper.state('targetItems').length, 0)
+
+  wrapper.setProps({ items: [ 'section-1', 'section-2', 'section-3' ] })
+
+  t.is(wrapper.state('targetItems').length, 3)
+})

--- a/test/test.js
+++ b/test/test.js
@@ -3,6 +3,7 @@ import React from 'react'
 import { shallow, mount, render } from 'enzyme'
 import { renderJSX, JSX } from 'jsx-test-helpers'
 import { Scrollspy } from '../src/js/lib/Scrollspy'
+import './document'
 
 test('renders correct markup', (t) => {
   const actual = renderJSX(


### PR DESCRIPTION
```es6
_initFromProps () {
  const targetItems = this._initSpyTarget(this.props.items)
  ...
}

componentWillReceiveProps () {
  this._initFromProps()
}
```

`this.props.items` are still the old items when calling `_initFromProps` in `componentWillReceiveProps`, so the component don't actually update.

I had to include `jsdom` to handle `document.getElementById` in the tests.