### PR TITLE
Only add scrolledPastClassName for items which have been scrolled past

### DIFF
--- a/src/js/lib/Scrollspy.jsx
+++ b/src/js/lib/Scrollspy.jsx
@@ -125,7 +125,7 @@ export class Scrollspy extends React.Component {
     const scrolledPastItems = viewStatusList.map((item) => {
       if (item && !hasFoundInView) {
         hasFoundInView = true
-        return item
+        return false
       }
       return !hasFoundInView
     })

--- a/src/js/lib/Scrollspy.jsx
+++ b/src/js/lib/Scrollspy.jsx
@@ -86,7 +86,7 @@ export class Scrollspy extends React.Component {
       inView: elemsInView,
       outView: elemsOutView,
       viewStatusList,
-      scrolledPast: this._getScrolledPast(viewStatusList),
+      scrolledPast: this.props.scrolledPastClassName && this._getScrolledPast(viewStatusList),
     }
   }
 


### PR DESCRIPTION
Had a minor bug in the implementation. `scrolledPastClassName` should only be added to items which are scrolled past, and not current items. This makes more sense. 

Also added a minor optimisation by only running `_getScrolledPast` if `scrolledPastClassName` is defined. 