### PR TITLE
Don't strip props on child components

### DIFF
--- a/src/js/lib/Scrollspy.jsx
+++ b/src/js/lib/Scrollspy.jsx
@@ -191,7 +191,7 @@ export class Scrollspy extends React.Component {
       })
 
       return (
-        <ChildTag className={ childClass } key={ counter++ }>
+        <ChildTag {...child.props} className={ childClass } key={ counter++ }>
           { child.props.children }
         </ChildTag>
       )

--- a/test/test.js
+++ b/test/test.js
@@ -14,3 +14,12 @@ test('renders correct children length', (t) => {
   )
   t.is(wrapper.find('li').length, 3)
 })
+
+test('renders children with correct props', (t) => {
+  const wrapper = shallow(
+    <Scrollspy items={ ['section-1'] } currentClassName="is-current">
+      <li className="" randomProp="someText"><a href="#section-1">section 1</a></li>
+    </Scrollspy>
+  )
+  t.is(wrapper.find('li').prop('randomProp'), 'someText')
+})


### PR DESCRIPTION
Right now if you props on direct children of `ScrollSpy` get stripped and only `className` gets passed. (I added a failing test demonstrating the issue)

This PR fixes the behavior so that children get passed their their original props in addition to the updated `className`.