### PR TITLE
Fix issue with Internet Explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "babel-cli": "^6.6.5",
     "babel-eslint": "^4.1.8",
     "babel-plugin-transform-object-assign": "^6.5.0",
+    "babel-polyfill": "^6.20.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "babel-register": "^6.11.6",

--- a/src/js/lib/Scrollspy.jsx
+++ b/src/js/lib/Scrollspy.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import classNames from 'classnames'
+import 'core-js/es6/array';  // polyfill Internet Explorer
 
 export class Scrollspy extends React.Component {
 


### PR DESCRIPTION
Array.prototype.fill() is not supported in IE 11 and earlier
(https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/fill)

This is fixed by using the babel-polyfill package and importing the array shim that we need.
(https://babeljs.io/docs/usage/polyfill/)