### PR TITLE
Replace Array.fill() with code safe for IE

### DIFF
--- a/src/js/lib/Scrollspy.jsx
+++ b/src/js/lib/Scrollspy.jsx
@@ -47,6 +47,12 @@ export class Scrollspy extends React.Component {
     return targetItems
   }
 
+  _fillArray (arr, val) {
+    for (var i = 0; i < arr.length; i++) {
+      arr[i] = val
+    }
+  }
+
   _getElemsViewState (targets) {
     let elemsInView = []
     let elemsOutView = []
@@ -75,7 +81,7 @@ export class Scrollspy extends React.Component {
         elemsOutView.pop()
         elemsOutView.push(...elemsInView)
         elemsInView = [currentContent]
-        viewStatusList.fill(false)
+        this._fillArray(viewStatusList, false)
         isInView = true
       }
 

--- a/src/js/lib/Scrollspy.jsx
+++ b/src/js/lib/Scrollspy.jsx
@@ -48,7 +48,7 @@ export class Scrollspy extends React.Component {
   }
 
   _fillArray (arr, val) {
-    for (var i = 0; i < arr.length; i++) {
+    for (let i = 0; i < arr.length; i++) {
       arr[i] = val
     }
   }


### PR DESCRIPTION
Array.prototype.fill() is not supported in IE 11 and earlier
(https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/fill)

This looks to be a better fix than https://github.com/makotot/react-scrollspy/pull/44