### PR TITLE
s/PropTypes/propTypes

### DIFF
--- a/src/js/lib/Scrollspy.jsx
+++ b/src/js/lib/Scrollspy.jsx
@@ -15,7 +15,7 @@ function isEqualArray(a, b) {
 
 export default class Scrollspy extends React.Component {
 
-  static get PropTypes () {
+  static get propTypes () {
     return {
       items: PropTypes.arrayOf(PropTypes.string).isRequired,
       currentClassName: PropTypes.string.isRequired,


### PR DESCRIPTION
Currently getting a warning in the console:

> Warning: Component Scrollspy declared `PropTypes` instead of `propTypes`. Did you misspell the property assignment?