### PR TITLE
Update PropTypes so that componentTag may accept a React Component as well as a String.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ Class name that apply to the navigation element paired with the content element 
 
 Class name that apply to the navigation elements that have been scrolled past [optional].
 
-### `componentTag={ String }`
+### `componentTag={ String | Function }`
 
-HTML tag for Scrollspy component if you want to use other than `ul` [optional].
+HTML tag or React Component for Scrollspy component if you want to use other than `ul` [optional].
 
 ### `style={ Object }`
 

--- a/src/js/lib/Scrollspy.jsx
+++ b/src/js/lib/Scrollspy.jsx
@@ -21,7 +21,7 @@ export default class Scrollspy extends React.Component {
       currentClassName: PropTypes.string.isRequired,
       scrolledPastClassName: PropTypes.string,
       style: PropTypes.object,
-      componentTag: PropTypes.string,
+      componentTag: PropTypes.oneOf([PropTypes.string, PropTypes.func]),
       offset: PropTypes.number,
       rootEl: PropTypes.string,
       onUpdate: PropTypes.func,

--- a/src/js/lib/Scrollspy.jsx
+++ b/src/js/lib/Scrollspy.jsx
@@ -21,7 +21,7 @@ export default class Scrollspy extends React.Component {
       currentClassName: PropTypes.string.isRequired,
       scrolledPastClassName: PropTypes.string,
       style: PropTypes.object,
-      componentTag: PropTypes.oneOf([PropTypes.string, PropTypes.func]),
+      componentTag: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
       offset: PropTypes.number,
       rootEl: PropTypes.string,
       onUpdate: PropTypes.func,


### PR DESCRIPTION
This was useful in my case to add aria attributes to the ul element. 

I think there may be many other use cases as well, like using a custom styled component or glamorous component. 

The only change that is needed is to the PropTypes to stop the warning.

Thank you for the awesome component!