### PR TITLE
Use the appropriate PropTypes for componentTag

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Class name that apply to the navigation element paired with the content element 
 
 Class name that apply to the navigation elements that have been scrolled past [optional].
 
-### `componentTag={ String | Function }`
+### `componentTag={ String | React element }`
 
 HTML tag or React Component for Scrollspy component if you want to use other than `ul` [optional].
 
@@ -75,7 +75,7 @@ Name of the element of scrollable container that can be used with querySelector 
 
 ### `onUpdate={ Function }`
 
-Function to be executed when the active item has been updated [Optional].
+Function to be executed when the active item has been updated [optional].
 
 ## Methods
 

--- a/src/js/lib/scrollspy.js
+++ b/src/js/lib/scrollspy.js
@@ -21,7 +21,7 @@ export default class Scrollspy extends React.Component {
       currentClassName: PropTypes.string.isRequired,
       scrolledPastClassName: PropTypes.string,
       style: PropTypes.object,
-      componentTag: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+      componentTag: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
       offset: PropTypes.number,
       rootEl: PropTypes.string,
       onUpdate: PropTypes.func,


### PR DESCRIPTION
Fix errors such as `Failed prop type: Invalid prop `componentTag` supplied to `Scrollspy`. in Scrollspy (created by DocsMenu)`