### PR TITLE
Add className props documentation in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ HTML tag or React Component for Scrollspy component if you want to use other tha
 
 Style attribute to be passed to the generated &lt;ul/&gt; element [optional].
 
+### `className={ String }`
+
+ClassName attribute to be passed to the generated &lt;ul/&gt; element [optional].
+
 ### `offset={ Number }`
 
 Offset value that adjusts to determine the elements are in the viewport [optional].


### PR DESCRIPTION
The `className` props have been forgotten in the typescript definition but you handle it in the code.
I guess it was because it is not present in the README.

@see : https://github.com/makotot/react-scrollspy/blob/master/src/js/lib/scrollspy.js#L254