### PR TITLE
quickfix for: https://github.com/makotot/react-scrollspy/issues/112

### DIFF
--- a/src/js/lib/scrollspy.js
+++ b/src/js/lib/scrollspy.js
@@ -243,7 +243,7 @@ export default class Scrollspy extends React.Component {
     this.offEvent()
   }
 
-  componentWillReceiveProps () {
+  UNSAFE_componentWillReceiveProps () {
     this._initFromProps()
   }
 


### PR DESCRIPTION
renamed unsafe lifecycle componentWillReceiveProps to UNSAFE_componentWillReceiveProps