### PR TITLE
Use PropTypes.elementType for componentTag

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ Class name that apply to the navigation element paired with the content element 
 
 Class name that apply to the navigation elements that have been scrolled past [optional].
 
-### `componentTag={ String | React element }`
+### `componentTag={ String | React element type }`
 
-HTML tag or React Component for Scrollspy component if you want to use other than `ul` [optional].
+HTML tag or React Component type for Scrollspy component if you want to use something other than `ul` [optional].
 
 ### `style={ Object }`
 

--- a/__test__/index.js
+++ b/__test__/index.js
@@ -31,3 +31,9 @@ test('renders expected html tag', (t) => {
   t.is(customTag.type(), 'div')
 })
 
+test('renders expected React Component', (t) => {
+  const MyComponent = () => {}
+  const customTag = shallow(<Scrollspy componentTag={MyComponent}></Scrollspy>)
+
+  t.is(customTag.type(), MyComponent)
+})

--- a/src/js/lib/scrollspy.js
+++ b/src/js/lib/scrollspy.js
@@ -21,7 +21,7 @@ export default class Scrollspy extends React.Component {
       currentClassName: PropTypes.string.isRequired,
       scrolledPastClassName: PropTypes.string,
       style: PropTypes.object,
-      componentTag: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+      componentTag: PropTypes.oneOfType([PropTypes.string, PropTypes.elementType]),
       offset: PropTypes.number,
       rootEl: PropTypes.string,
       onUpdate: PropTypes.func,

--- a/src/js/props-table.js
+++ b/src/js/props-table.js
@@ -23,7 +23,7 @@ const PropTable = () => (
       </tr>
       <tr>
         <td className="table__data">componentTag</td>
-        <td className="table__data">HTML tag for Scrollspy component if you want to use other than <code>{'<ul/>'}</code> [optional].</td>
+        <td className="table__data">HTML tag or React Component type for Scrollspy component if you want to use something other than <code>{'<ul/>'}</code> [optional].</td>
       </tr>
       <tr>
         <td className="table__data">style</td>


### PR DESCRIPTION
Previously, the type checking looked for a React element (eg an instantiated object, `<MyComponent />`) but the implementation required a type (eg `MyComponent`) in order to work -- eg the `Tag` is a type used at https://github.com/makotot/react-scrollspy/blob/master/src/js/lib/scrollspy.js#L284.

This PR updates the type checking to use `PropTypes.elementType`, updates the documentation, adds a test to ensure the type is correct when a React element type is passed to `componentTag`.

Fixes and expands upon #119