### PR TITLE
Pass through props to the componentTag

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ Name of the element of scrollable container that can be used with querySelector 
 
 Function to be executed when the active item has been updated [optional].
 
+### Other props
+
+All other props are passed through to the underlying HTML tag or React Component specified in the `componentTag` prop [optional].
+
 ## Methods
 
 ### `offEvent`

--- a/__test__/index.js
+++ b/__test__/index.js
@@ -23,6 +23,17 @@ test('renders children with correct props', (t) => {
   t.is(wrapper.find('li').prop('randomProp'), 'someText')
 })
 
+test('renders component and passed through props', (t) => {
+  const MyComponent = () => {}
+  const otherProps = { randomProp: 'someText' }
+  const wrapper = shallow(<Scrollspy componentTag={ MyComponent } firstProp={1} secondProp { ...otherProps }></Scrollspy>)
+
+  t.is(wrapper.type(), MyComponent)
+  t.is(wrapper.prop('firstProp'), 1)
+  t.is(wrapper.prop('secondProp'), true)
+  t.is(wrapper.prop('randomProp'), 'someText')
+})
+
 test('renders expected html tag', (t) => {
   const defaultTag = shallow(<Scrollspy></Scrollspy>)
   const customTag = shallow(<Scrollspy componentTag={ 'div' }></Scrollspy>)

--- a/src/js/lib/scrollspy.js
+++ b/src/js/lib/scrollspy.js
@@ -254,6 +254,7 @@ export default class Scrollspy extends React.Component {
       className,
       scrolledPastClassName,
       style,
+      ...passThroughProps
     } = this.props
     let counter = 0
     const items = React.Children.map(children, (child, idx) => {
@@ -281,7 +282,7 @@ export default class Scrollspy extends React.Component {
     })
 
     return (
-      <Tag className={ itemClass } style={ style }>
+      <Tag className={ itemClass } style={ style } { ...passThroughProps }>
         { items }
       </Tag>
     )


### PR DESCRIPTION
This passes all other props, other than those used by ScrollSpy, to the underlying `componentTag`.

This fixes #86 and is a more generic solution than #164, working for _all_ props, including `id`.

PR includes documentation updates and unit tests to ensure props are passed through.